### PR TITLE
expand chart functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode/
+.idea/

--- a/cloud-custodian-cron/Chart.yaml
+++ b/cloud-custodian-cron/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: cloud-custodian-cron
 description: Cloud Custodian helm chart allowing use of cron jobs to schedule policy runs 
 type: application
-version: 0.1.0
-appVersion: 0.9.9
+version: 0.2.0
+appVersion: 0.9.11.0

--- a/cloud-custodian-cron/README.md
+++ b/cloud-custodian-cron/README.md
@@ -11,6 +11,7 @@ Cloud Custodian helm chart allowing use of cron jobs to schedule policy runs
 | affinity | object | `{}` | Optional affinity rules |
 | nodeSelector | object | `{}` | Optional node selector rules |
 | tolerations | list | `[]` | Optional tolerations to apply to the pod |
+| restartPolicy | string| `Never` | restartPolicy of CronJob |
 | podAnnotations | object | `{}` | Optional pod annotations |
 | fullnameOverride | string | `""` |  |
 | nameOverride | string | `""` |  |
@@ -21,6 +22,7 @@ Cloud Custodian helm chart allowing use of cron jobs to schedule policy runs
 | image.repository | string | `"cloudcustodian/c7n"` |  |
 | imagePullSecrets | list | `[]` |  |
 | envVars | object | `{}` | Extra environment variables to pass to cloud custodian  |
+| args | list | `[ "run","-v","-s","/home/custodian/output","/home/custodian/policies.yaml" ]` | Default custodian args  |  
 | resources | object | `{}` | Optional resources requests/limits |
 | scheduledPolicies[].concurrencyPolicy | object | `{}` |  The cron job's concurrency policy |
 | scheduledPolicies[].failedJobsHistoryLimit | int | `10` | Limit of how many failed jobs history to keep  |
@@ -30,3 +32,14 @@ Cloud Custodian helm chart allowing use of cron jobs to schedule policy runs
 | scheduledPolicies[].successfulJobsHistoryLimit | int | `10` | Limit of how many failed jobs history to keep |
 | securityContext | object | `{}` |  |
 | serviceAccount.annotations | object | `{}` | Optional service account annotations |
+| persistence.enabled | bool | `false` | Persistence volume to save output & cache |
+| persistence.extraLabels | object | `{}` | Persistence volume extra labels |
+| persistence.annotations | object | `{}` | Persistence annotations |
+| persistence.existingClaim | string | `""` | Persistence existingClaim volume |
+| persistence.accessMode | string | `""` | Persistence volume accessMode |
+| persistence.storageSize | string | `5Gi` | Persistence volume storageSize |
+| persistence.storageClassName | string | `""` | Persistence storageClassName |
+| secret.enabled | bool | `false` | Use external secret for custodian instead of using Envars as secrets |
+| secret.secretName | string | `""` | secretName for custodian  |
+| secret.mountPath | string | `/home/custodian/.aws` | secretName for custodian  |
+| secret.readOnly | string | `true` | secretName readOnly |

--- a/cloud-custodian-cron/templates/cronjob.yaml
+++ b/cloud-custodian-cron/templates/cronjob.yaml
@@ -3,7 +3,7 @@
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: "{{ include "cloud-custodian-cron.fullname" $ }}-{{ $scheduledPolicy.name }}"
+  name: {{ include "cloud-custodian-cron.fullname" $ }}-{{ $scheduledPolicy.name }}
   labels:
     {{- include "cloud-custodian-cron.labels" $ | nindent 4 }}
 spec:
@@ -24,6 +24,18 @@ spec:
             {{- include "cloud-custodian-cron.selectorLabels" $ | nindent 12 }}
         spec:
           volumes:
+          {{- if $.Values.secret.enabled }}
+          - name: {{ template "cloud-custodian-cron.fullname" $ }}-secret
+            secret:
+              secretName: {{ $.Values.secret.secretName }}
+          {{- end }}
+          - name: {{ include "cloud-custodian-cron.fullname" $ }}-data
+          {{- if $.Values.persistence.enabled }}
+            persistentVolumeClaim:
+              claimName: {{ $.Values.persistence.existingClaim | default (printf "%s-%s" (include "cloud-custodian-cron.fullname" $ ) "data") }}
+          {{- else }}
+            emptyDir: {}
+          {{- end }}
           - name: policy
             configMap:
               name: "{{ include "cloud-custodian-cron.fullname" $ }}-{{ $scheduledPolicy.name }}"
@@ -40,14 +52,25 @@ spec:
               {{- toYaml $.Values.securityContext | nindent 14 }}
             image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag | default $.Chart.AppVersion }}"
             imagePullPolicy: {{ $.Values.image.pullPolicy }}
-            args: ["-v", "-s", "/home/custodian/policies.yml"]
+            args:
+            {{- range $.Values.args }}
+            - {{ . | quote }}
+            {{- end }}
             {{- with $.Values.envVars }}
             env:
               {{- toYaml . | nindent 14 }}
             {{- end }}
             volumeMounts:
             - name: policy
+              mountPath: /home/custodian/policies.yaml
+              subPath: policies.yaml
+            - name: {{ include "cloud-custodian-cron.fullname" $ }}-data
               mountPath: /home/custodian
+            {{- if $.Values.secret.enabled }}
+            - mountPath: {{ default "/home/custodian/.aws" $.Values.secret.mountPath }}
+              name: {{ template "cloud-custodian-cron.fullname" $ }}-secret
+              readOnly: {{ default "true" $.Values.secret.readOnly }}
+            {{- end }}
             resources:
               {{- toYaml $.Values.resources | nindent 14 }}
           {{- with $.Values.nodeSelector }}
@@ -62,4 +85,5 @@ spec:
           tolerations:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          restartPolicy: {{ $.Values.restartPolicy | default "Never" | quote }}
 {{- end }}

--- a/cloud-custodian-cron/templates/pvc.yaml
+++ b/cloud-custodian-cron/templates/pvc.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "cloud-custodian-cron.fullname" . }}-data
+  labels:
+{{ include "cloud-custodian-cron.labels" . | indent 4 }}
+{{- if .Values.persistence.extraLabels }}
+{{- with .Values.persistence.extraLabels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- end }}
+{{- if .Values.persistence.annotations }}
+  annotations:
+{{ toYaml .Values.persistence.annotations | indent 4 }}
+{{- end }}
+spec:
+  accessModes:
+  - {{ default "ReadWriteOnce" .Values.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ default "5Gi" .Values.persistence.storageSize | quote }}
+{{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClassName }}
+  {{- end }}
+{{- end }}

--- a/cloud-custodian-cron/values.yaml
+++ b/cloud-custodian-cron/values.yaml
@@ -28,3 +28,18 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+args:
+- "run"
+- "-v"
+- "-s /home/custodian/output"
+- "/home/custodian/policies.yaml"
+
+persistence:
+  enabled: false
+  extraLabels: {}
+  annotations: {}
+
+secret:
+  enabled : false
+  secretName: {}


### PR DESCRIPTION
Expand cloud custodian helm chart functionality to support:

- Persistence Volume / Existing Persistence volume claim.
- Customize args.
- Ability to use external secret instead of envars as secrets.
- Upgrade image version to 9.11.0.
- Add CronJob restartPolicy.